### PR TITLE
Add pyflexplot to automatic workflow

### DIFF
--- a/flex_container_orchestrator/config/.env
+++ b/flex_container_orchestrator/config/.env
@@ -36,7 +36,7 @@ S3_ACCESS_KEY=<secret data>
 S3_SECRET_KEY=<secret data>
 
 ## IMAGE
-FLEXPART_TAG=2411.b41e06a177edb101e546f6b180b342e7e32bff8f
+FLEXPART_TAG=2411.abb884c4add463ea64544488ed30acec79be41fe
 FLEXPART_ECR_REPO=493666016161.dkr.ecr.eu-central-2.amazonaws.com/numericalweatherpredictions/dispersionmodelling/flexpart-ifs/flexpart-containerize
 
 ## Time settings
@@ -46,3 +46,23 @@ TDELTA=6
 TFREQ_F=6
 # Frequency of IFS runs in hour(s)
 TFREQ=6
+
+#----------- Pyflexplot
+
+## Input/output S3 bucket settings
+MAIN__AWS__S3__INPUT__NAME=flexpart-output
+MAIN__AWS__S3__OUTPUT__NAME=pyflexplot-output
+MAIN__AWS__S3__INPUT__ENDPOINT_URL=https://object-store.os-api.cci1.ecmwf.int
+MAIN__AWS__S3__OUTPUT__ENDPOINT_URL=https://object-store.os-api.cci1.ecmwf.int
+## EWC buckets access and secret keys
+MAIN__AWS__S3__INPUT__S3_ACCESS_KEY=<secret data>
+MAIN__AWS__S3__INPUT__S3_SECRET_KEY=<secret data>
+MAIN__AWS__S3__OUTPUT__S3_ACCESS_KEY=<secret data>
+MAIN__AWS__S3__OUTPUT__S3_SECRET_KEY=<secret data>
+
+## Specific NWP model
+preset=opr/ifs-hres-eu/all_pdf
+
+## IMAGE
+PYFLEXPLOT_TAG=2411.35a30e3ba6ce01d8537b8497fff8ebc042bcc39c
+PYFLEXPLOT_ECR_REPO=493666016161.dkr.ecr.eu-central-2.amazonaws.com/numericalweatherpredictions/dispersionmodelling/flexpart-ifs/pyflexplot


### PR DESCRIPTION
This PR integrates [Pyflexplot](https://github.com/MeteoSwiss-APN/pyflexplot), enabling the generation of plots from FLEXPART results, into the existing workflow, where FLEXPART is triggered each time an IFS run occurs.

Note: to be merged in `main` when [trigger_aggregation_flexpartjob](https://github.com/MeteoSwiss/flex-container-orchestrator/tree/trigger_aggregation_flexpartjob)(https://github.com/MeteoSwiss/flex-container-orchestrator/pull/1) is merged